### PR TITLE
Add a lowercase alias for Contactor formula

### DIFF
--- a/Aliases/contactor
+++ b/Aliases/contactor
@@ -1,0 +1,1 @@
+../Contactor.rb


### PR DESCRIPTION
Homebrew has issues on HFS+ case-sensitive drives when dealing with non-lowercase formulae.

I happen to be running my MacOS machine on such a drive, which makes it
impossible for me to install Contactor normally:

```
maddy ♥ ~ » brew tap kettle/kettle                                                                                                                  [3:12:46]
==> Tapping kettle/kettle
Cloning into '/usr/local/Homebrew/Library/Taps/kettle/homebrew-kettle'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Tapped 1 formula (29 files, 24KB).
maddy ♥ ~ » brew install Contactor                                                                                                                  [3:12:56]
Error: No available formula with the name "contactor"
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching for similarly named formulae...
This similarly named formula was found:
kettle/kettle/Contactor
To install it, run:
  brew install kettle/kettle/Contactor
==> Searching taps...
==> Searching taps on GitHub...
Error: No formulae found in taps.
maddy ♥ ~ » brew install kettle/kettle/Contactor                                                                                                    [3:13:14]
Error: No available formula with the name "kettle/kettle/contactor"
==> Searching for a previously deleted formula (in the last month)...
Warning: kettle/kettle is shallow clone. To get complete history run:
  git -C "$(brew --repo kettle/kettle)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
```

However, by adding a lowercase alias pointing to the Contactor formula, it works fine:

```
maddy ♥ ~ » mkdir /usr/local/Homebrew/Library/Taps/kettle/homebrew-kettle/Aliases                                                                   [3:13:28]
maddy ♥ ~ » ln -s /usr/local/Homebrew/Library/Taps/kettle/homebrew-kettle/{Contactor.rb,Aliases/contactor}                                          [3:13:42]
maddy ♥ ~ » brew install Contactor                                                                                                                  [3:13:50]
==> Installing Contactor from kettle/kettle
==> Downloading https://github.com/kettle/Contactor/releases/download/1.2.6/Contactor-1.2.6.tar.gz
Already downloaded: /Users/maddy/Library/Caches/Homebrew/downloads/8b0b2670f2558bab2f96f42665831fca4cfb303cecc652deb13c316b030ebab5--Contactor-1.2.6.tar.gz
�  /usr/local/Cellar/Contactor/1.2.6: 3 files, 723.2KB, built in 5 seconds
```

Homebrew's official repositories do not contain any formulae with a capital letter in their names, presumably due to this issue:

```
maddy ♥ ~ » find /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula -mindepth 1 -name '*[A-Z]*' | wc -l
0
```

This PR should fix the issue for the Contactor formula inside this repository.

I suggest you consider either naming future formulae with the all-lowercase
convention, or remember to add lowercase aliases.